### PR TITLE
Add incomplete to example; bump to version 0.0.3

### DIFF
--- a/src/examples/complete.yml
+++ b/src/examples/complete.yml
@@ -17,6 +17,7 @@ usage:
         - qlty/coverage_publish:
             files: coverage/lcov.info
             tag: units
+            incomplete: true
         # Later, mark coverage collection as complete
         - qlty/coverage_complete:
             tag: units

--- a/src/examples/complete.yml
+++ b/src/examples/complete.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    qlty: qltysh/qlty-orb@0.0.2
+    qlty: qltysh/qlty-orb@0.0.3
   jobs:
     upload_coverage:
       docker:

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    qlty: qltysh/qlty-orb@0.0.2
+    qlty: qltysh/qlty-orb@0.0.3
   jobs:
     run_tests_and_publish_coverage:
       docker:


### PR DESCRIPTION
Fixed `complete` example to ensure partials are uploaded with an `incomplete: true` flag.

Also, thinking about versioning. When we're before 1.x it's a challenging place to be because:

- Users will be required to bump their orb version every time to get new flags even if those flags are backwards compatible changes
- Or, we could use a "floating" version either `@volatile` or `dev:feature-1` but neither is ideal and both would require orb users to change their .circleci/config.yml when we hit 1.x status

I recommend we move to a 1.x very soon or at least identify what gaps exist to us getting there.
