### PR TITLE
Fix skip_errors behaviour on final eval

### DIFF
--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -110,9 +110,7 @@ redacted_command=$(printf "%s\n" "$command" | awk '{
 echo "Running: $redacted_command"
 
 # Execute the command
+eval "$command"
 if [ "$PARAM_SKIP_ERRORS" = "true" ]; then
-  eval "$command"
   exit 0
-else
-  eval "$command"
 fi


### PR DESCRIPTION
Previously the exit code of the final eval was always returned. 
If skip_error was set to true but the final qlty command run errored, the CI would fail as the return code from qlty will be sent as the final exit code.
This PR makes sure exit 0 is called when skip_errors is true