### PR TITLE
Run linux-basic-upload-test only on branch builds

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,9 +37,9 @@ workflows:
       - linux-basic-upload-test:
           filters:
             branches:
-              only: /.*/        # Run on all branches
+              only: /.*/ # Run on all branches
             tags:
-              ignore: /.*/      # Ignore all tags
+              ignore: /.*/ # Ignore all tags
 
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:


### PR DESCRIPTION
Circle CI runs triggered by tags don't have a CIRCLE_BRANCH env var set and the test-deploy is triggered by tag, since we added a validation on Branch name https://github.com/qltysh/qlty/blob/main/qlty-cli/src/commands/coverage/utils.rs#L146
The run is now failing due to missing CIRCLE_BRANCH https://app.circleci.com/pipelines/circleci/GLozhJGDmUohfUJDwN6WHX/9ytbFjApfMKhVqnv4d6aot/59/workflows/3ca9c947-5461-4b1c-b1a8-b0cee0c8cec6/jobs/329

So working around this by running linux-basic-upload-test only on branch builds