### PR TITLE
Fix skip_errors behaviour

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,10 +26,9 @@ jobs:
     steps:
       - checkout
       - qlty-orb/coverage_publish:
-          files: coverage/coverage_0.json, coverage/coverage_2.json
+          files: coverage/coverage_0.json, coverage/coverage_1.json
           working_directory: ~/project/fixtures/basic-ruby
           strip_prefix: /home/repos/qlty-testing-orb
-          skip_errors: false
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - checkout
       - qlty-orb/coverage_publish:
-          files: coverage/coverage_0.json, coverage/coverage_1.json
+          files: coverage/coverage_0.json, coverage/coverage_2.json
           working_directory: ~/project/fixtures/basic-ruby
           strip_prefix: /home/repos/qlty-testing-orb
 workflows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,6 +29,7 @@ jobs:
           files: coverage/coverage_0.json, coverage/coverage_2.json
           working_directory: ~/project/fixtures/basic-ruby
           strip_prefix: /home/repos/qlty-testing-orb
+          skip_errors: false
 workflows:
   test-deploy:
     jobs:

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "PARAM_SKIP_ERRORS:"
+echo "$PARAM_SKIP_ERRORS"
+
 if [ "$PARAM_SKIP_ERRORS" != "1" ]; then
   set -e
 fi

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -109,11 +109,6 @@ redacted_command=$(printf "%s\n" "$command" | awk '{
 # Print the redacted command
 echo "Running: $redacted_command"
 
-if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
-  echo "Skipping errors as requested."
-  set +e  # Ensure 'set -e' is off so we can handle errors manually
-fi
-
 # Execute the command
 eval "$command"
 exit 0

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-echo "PARAM_SKIP_ERRORS:"
-echo "$PARAM_SKIP_ERRORS"
-
-if [ "$PARAM_SKIP_ERRORS" != "1" ]; then
-  set -e
+if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
+  set +e # Disable exit on error
 fi
 
 QLTY_CMD="$HOME/.qlty/bin/qlty"
@@ -119,13 +116,4 @@ fi
 
 # Execute the command
 eval "$command"
-exit_code=$?
-echo "Command exited with code: $exit_code"
-
-if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
-  echo "Expect to exit 0."
-  exit 0
-else
-  echo "Expect to exit any."
-  exit $exit_code
-fi
+exit 0

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -114,6 +114,7 @@ echo "Running: $redacted_command"
 
 if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
   echo "Skipping errors as requested."
+  set +e  # Ensure 'set -e' is off so we can handle errors manually
 fi
 
 # Execute the command

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -118,6 +118,12 @@ fi
 
 # Execute the command
 eval "$command"
+exit_code=$?
+
 if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
+  echo "Expect to exit 0."
   exit 0
+else
+  echo "Expect to exit any."
+  exit $exit_code
 fi

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -112,6 +112,10 @@ redacted_command=$(printf "%s\n" "$command" | awk '{
 # Print the redacted command
 echo "Running: $redacted_command"
 
+if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
+  echo "Skipping errors as requested."
+fi
+
 # Execute the command
 eval "$command"
 if [ "$PARAM_SKIP_ERRORS" = "1" ]; then

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
-  set +e # Disable exit on error
+  # https://circleci.com/docs/configuration-reference/#default-shell-options
+  # By default, CircleCI runs commands with `set -e`, which causes the script to exit immediately if any command fails.
+  set +e
 fi
 
 QLTY_CMD="$HOME/.qlty/bin/qlty"

--- a/src/scripts/publish
+++ b/src/scripts/publish
@@ -119,6 +119,7 @@ fi
 # Execute the command
 eval "$command"
 exit_code=$?
+echo "Command exited with code: $exit_code"
 
 if [ "$PARAM_SKIP_ERRORS" = "1" ]; then
   echo "Expect to exit 0."


### PR DESCRIPTION
So apparently `set -e` is set by default in Circle CI env, you have to explicitly `set +e` if you want to repress errors which is opposite to convention.